### PR TITLE
Bump WdCuration version on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,12 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+search = version="{current_version}"
+replace = version="{new_version}"
 
 [bumpversion:file:wdcuration/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/lubianat/wdcuration",
-    version="0.1.3",
+    version="0.2.0",
     zip_safe=False,
 )

--- a/wdcuration/__init__.py
+++ b/wdcuration/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Tiago Lubiana"""
 __email__ = "tiago.lubiana.alves@usp.br"
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 
 from .wdcuration import (
     query_wikidata,


### PR DESCRIPTION
Already bumped on PyPI, this is just to sync the repo.

- fix: Add double quotes to bumpversion cfg
- Bump version: 0.1.3 → 0.2.0
